### PR TITLE
ICDC-2979

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -2,9 +2,26 @@ schema {
   query: QueryType
 }
 
+type StudyMiscMetadata {
+  cancer_type: String
+  doi: String
+  species: String
+  subject_count: Int
+}
+
+type StudyPrimaryMetadata {
+  collection_id: String
+  date: String
+  description: String
+  modality: String
+  location: String
+  misc: StudyMiscMetadata
+}
+
 type Link {
-  text: String
+  repository: String
   url: String
+  metadata: StudyPrimaryMetadata
 }
 
 type StudyOfProgram {


### PR DESCRIPTION
- return all data from IDC `/collections` endpoint for ICDC-relevant image collections (https://tracker.nci.nih.gov/browse/ICDC-2979)

- update app schema to handle additional response data (generalize response fields that are shared between IDC and TCIA image collection endpoints --> see image)
![Untitled Diagram drawio](https://user-images.githubusercontent.com/51423770/218589359-b23604e9-3efe-4ba3-b9a4-ac82c06faac9.png)

- updated query:
<code>
{
    studiesByProgram {
        CRDCLinks {
            url,
            repository,
            metadata {
                collection_id,
                date,
                description,
                modality,
                location,
                misc {
                    cancer_type,
                    doi,
                    species,
                    subject_count
                }
            }
        },
        numberOfCRDCNodes, 
        numberOfImageCollections
    }
}
</code>