### PR TITLE
update TCIA response property names

### DIFF
--- a/data-management/data-interface.js
+++ b/data-management/data-interface.js
@@ -158,10 +158,10 @@ async function mapCollectionsToStudies() {
               // specify explicit type of metadata returned for GraphQL union
               __typename: "TCIAMetadata",
               Collection: tciaMatches[match],
-              total_patientIDs: totalPatients,
+              total_patient_IDs: totalPatients,
               unique_modalities: uniqueModalities,
-              unique_bodypartsExamined: uniqueBodypartsExamined,
-              total_imageCounts: totalImages,
+              unique_bodyparts_examined: uniqueBodypartsExamined,
+              total_image_counts: totalImages,
             },
           });
           numImageCollections++;

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -17,10 +17,10 @@ type IDCMetadata {
 
 type TCIAMetadata {
   Collection: String
-  total_patientIDs: Int
+  total_patient_IDs: Int
   unique_modalities: [String]
-  unique_bodypartsExamined: [String]
-  total_imageCounts: Int
+  unique_bodyparts_examined: [String]
+  total_image_counts: Int
 }
 
 union Metadata = IDCMetadata | TCIAMetadata


### PR DESCRIPTION
- make TCIA response property name format consistent to reduce front end logic

`total_patientIDs` ---> `total_patient_IDs`
`unique_bodypartsExamined` ---> `unique_bodyparts_examined`
`total_imageCounts` ---> `total_image_counts`