### PR TITLE
remove URLs from and further format description text in TCIA response (ICDC-3030)

### DIFF
--- a/data-management/data-interface.js
+++ b/data-management/data-interface.js
@@ -130,7 +130,10 @@ async function mapCollectionsToStudies(parameters) {
           const cleanedDescText = htmlToText(
             idcCollectionMetadata["description"],
             { wordwrap: null }
-          ).replace(/\r?\n/g, " ");
+          )
+            .replace(/\n\n|\s*\[.*?\]\s*/g, " ")
+            .replace(/ \./g, ".")
+            .replace(" ICDC-Glioma", "");
           idcCollectionMetadata["description"] = cleanedDescText;
           // specify explicit type of metadata returned for GraphQL union
           idcCollectionMetadata["__typename"] = "IDCMetadata";


### PR DESCRIPTION
- the raw description text from the TCIA API contains some oddities (ex: seemingly random line breaks, anchor element text that fits/makes sense in one sentence but not another, etc.) that made this slightly more difficult than expected, requiring the use of the `html-to-text` package + a few regular expressions to clean up the text...

**result:**
```json
"ICDC-Glioma contains treatment-naïve naturally-occurring canine glioma participants from the Integrated Canine Data Commons. Brain radiology (57/81 participant animals) and H&E-stained biopsy or necropsy pathology (76/81 participants) are classified by veterinary and physician neuropathologists. Please see the wiki to learn more about the images and to obtain any supporting metadata for this collection."
```